### PR TITLE
changed ground object layer from separete pieces to one big

### DIFF
--- a/game/android/assets/map/straightMap.tmx
+++ b/game/android/assets/map/straightMap.tmx
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<map version="1.2" tiledversion="1.3.3" orientation="orthogonal" renderorder="right-down" width="30" height="10" tilewidth="64" tileheight="64" infinite="0" nextlayerid="6" nextobjectid="49">
+<map version="1.2" tiledversion="1.3.3" orientation="orthogonal" renderorder="right-down" width="30" height="10" tilewidth="64" tileheight="64" infinite="0" nextlayerid="6" nextobjectid="55">
  <tileset firstgid="1" name="background" tilewidth="128" tileheight="128" tilecount="35" columns="7">
   <image source="background.png" width="1000" height="750"/>
  </tileset>
@@ -35,35 +35,6 @@
 </data>
  </layer>
  <objectgroup id="5" name="walkingGround">
-  <object id="18" x="-0.333333" y="448" width="64.6667" height="63.6667"/>
-  <object id="19" x="63.6666" y="448.5" width="64.6667" height="63.6667"/>
-  <object id="21" x="128" y="448.5" width="64.6667" height="63.6667"/>
-  <object id="22" x="191" y="448.5" width="64.6667" height="63.6667"/>
-  <object id="23" x="255.333" y="448.167" width="64.6667" height="63.6667"/>
-  <object id="24" x="320" y="448.833" width="64.6667" height="63.6667"/>
-  <object id="25" x="383.333" y="448.833" width="64.6667" height="63.6667"/>
-  <object id="26" x="447.333" y="448.5" width="64.6667" height="63.6667"/>
-  <object id="27" x="512" y="448.167" width="64.6667" height="63.6667"/>
-  <object id="28" x="576" y="448.167" width="64.6667" height="63.6667"/>
-  <object id="29" x="639.333" y="447.5" width="64.6667" height="63.6667"/>
-  <object id="30" x="703" y="447.833" width="64.6667" height="63.6667"/>
-  <object id="31" x="767" y="448.167" width="64.6667" height="63.6667"/>
-  <object id="32" x="831.333" y="448.167" width="64.6667" height="63.6667"/>
-  <object id="33" x="896.333" y="448.5" width="64.6667" height="63.6667"/>
-  <object id="34" x="961" y="447.5" width="64.6667" height="63.6667"/>
-  <object id="35" x="1024.33" y="447.833" width="64.6667" height="63.6667"/>
-  <object id="36" x="1088.67" y="448.167" width="64.6667" height="63.6667"/>
-  <object id="37" x="1152.33" y="448.5" width="64.6667" height="63.6667"/>
-  <object id="38" x="1216.33" y="448.167" width="64.6667" height="63.6667"/>
-  <object id="39" x="1280" y="448.167" width="64.6667" height="63.6667"/>
-  <object id="40" x="1343.67" y="448.5" width="64.6667" height="63.6667"/>
-  <object id="41" x="1408" y="448.167" width="64.6667" height="63.6667"/>
-  <object id="42" x="1472" y="448.5" width="64.6667" height="63.6667"/>
-  <object id="43" x="1536.33" y="447.833" width="64.6667" height="63.6667"/>
-  <object id="44" x="1599.67" y="447.833" width="64.6667" height="63.6667"/>
-  <object id="45" x="1664" y="447.833" width="64.6667" height="63.6667"/>
-  <object id="46" x="1728" y="448.167" width="64.6667" height="63.6667"/>
-  <object id="47" x="1791.67" y="447.833" width="64.6667" height="63.6667"/>
-  <object id="48" x="1855" y="448.167" width="64.6667" height="63.6667"/>
+  <object id="50" x="0" y="448" width="1920" height="64"/>
  </objectgroup>
 </map>


### PR DESCRIPTION
Straightmap.tmx changed from having one rectangle object around each tile to having one big rectangle object across the entire ground. This fixes the issue for when animals gets stuck between two ground-tiles because of height difference.